### PR TITLE
WL-4238 Syllabus tool now shows dates up to 2025.

### DIFF
--- a/syllabus-app/src/webapp/js/jqueryui-editable.js
+++ b/syllabus-app/src/webapp/js/jqueryui-editable.js
@@ -4267,7 +4267,7 @@ $(function(){
         //initial value, can be `new Date()`    
         value: null,                       
         minYear: 1970,
-        maxYear: 2015,
+        maxYear: 2025,
         yearDescending: true,
         minuteStep: 5,
         secondStep: 1,


### PR DESCRIPTION
Changed maxyear to 2025 in jqueryui-editable.js.
